### PR TITLE
style(storybook): fix sidebar background color overridden by css-in-js generated class

### DIFF
--- a/packages/fractal/.storybook/manager-head.html
+++ b/packages/fractal/.storybook/manager-head.html
@@ -161,7 +161,7 @@ build Snowball's products, apps, marketing contents and documentations"
   }
 
   .sidebar-container {
-    background-color: black;
+    background: black !important;
   }
 
   div[role='main'] > div {


### PR DESCRIPTION
## Summary

- The Storybook sidebar container had its background color overridden by a CSS-in-JS generated class using the `background` shorthand property
- Replaced the background-color declaration on .sidebar-container with background: black !important to ensure the correct background is applied regardless of CSS-in-JS class order.

### Before
<img width="309" height="670" alt="Capture d’écran 2026-04-24 à 16 11 54" src="https://github.com/user-attachments/assets/962e0a24-d802-4e78-8308-51b2b8509ce1" />

### After
<img width="308" height="666" alt="Capture d’écran 2026-04-24 à 21 40 53" src="https://github.com/user-attachments/assets/ac63b685-9512-4fbf-a442-11cc6c64adb3" />

## Test plan

- [ ] Open Storybook and verify the sidebar background is black
- [ ] Check on mobile view that the drawer background is also black