### PR TITLE
docs(fractal): replace pandacss references with tailwindcss

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,6 +74,3 @@ next-env.d.ts
 scripts/tmp
 # This file is only used for the Tailwind VSCode extension.
 tailwind.config.cjs
-
-# PandaCSS.
-styled-system*

--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ There are currently **2** packages available in Fractal:
   and packages throughout the organization;
 
 - **[fractal](./packages/fractal)**: the React component library, made of
-  components, styles, icons, ... based on Radix-UI and PandaCSS and to be used
+  components, styles, icons, ... based on Radix-UI and TailwindCSS and to be used
   in web (React) applications.  
   It also contains the Storybook documentation that is uploaded to Chromatic and
   the main documentation webiste.

--- a/packages/fractal/package.json
+++ b/packages/fractal/package.json
@@ -44,7 +44,7 @@
     "tailwind-merge": "2.6.1",
     "tailwindcss": "3.4.19"
   },
-  "description": "Fractal's (Snowball's design system) React component library based on RadixUI and PandaCSS",
+  "description": "Fractal's (Snowball's design system) React component library based on RadixUI and TailwindCSS",
   "devDependencies": {
     "@csstools/postcss-cascade-layers": "6.0.0",
     "@snowball-tech/eslint-snowball-config": "2.1.0",


### PR DESCRIPTION
## Summary

- Updated `README.md`: replaced "Radix-UI and PandaCSS" with "Radix-UI and TailwindCSS"
- Updated `packages/fractal/package.json` description: replaced "PandaCSS" with "TailwindCSS"
- Removed obsolete `# PandaCSS. / styled-system*` entry from `.gitignore`

The changelog (v4.0.0) documents the migration from PandaCSS to TailwindCSS; these were the remaining stale references in the docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)