### PR TITLE
docs: add AGENTS.md and CLAUDE.md for AI coding agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,25 @@
+# AGENTS.md
+
+Guidance for AI coding agents working in **Fractal**, Snowball's design system
+mono-repository.
+
+> **Single source of truth:** [`CLAUDE.md`](./CLAUDE.md).
+> It holds the parts of this repo an agent won't find documented elsewhere
+> (component-authoring pattern, release automation, Storybook MCP). **Read it
+> first.** This file only points you to it and the rest of the docs.
+
+## Documentation
+
+- [`CLAUDE.md`](./CLAUDE.md) — start here
+- [`README.md`](./README.md) — repo overview, setup
+- [`CONTRIBUTING.md`](./CONTRIBUTING.md) — testing requirement, SemVer,
+  Conventional Commits, Boy Scout Rule
+- [`docs/CONVENTIONS.md`](./docs/CONVENTIONS.md) — code style, component
+  guidelines
+- [`docs/TOOLING.md`](./docs/TOOLING.md) — Yarn workspaces, Vercel, Renovate,
+  VSCode
+- [`docs/TROUBLESHOOTING.md`](./docs/TROUBLESHOOTING.md) — FAQ & known issues
+- [`packages/design-tokens/DESIGN.md`](./packages/design-tokens/DESIGN.md) —
+  brand/visual-language brief (colors, typography, shadows, do's/don'ts)
+- [`packages/fractal/README.md`](./packages/fractal/README.md) —
+  package-specific dev workflow, including the Storybook MCP setup

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,76 @@
+# Fractal — CLAUDE.md
+
+This covers only the parts of this repo that aren't already documented
+elsewhere. For everything else, see [`AGENTS.md`](./AGENTS.md) for the full
+doc index.
+
+## What this repo is
+
+A 2-package Yarn Berry v4 monorepo:
+
+- `packages/fractal` — the React/Radix-UI/TailwindCSS component library,
+  published as `@snowball-tech/fractal`.
+- `packages/design-tokens` — JSON design tokens + `DESIGN.md` brand brief,
+  published as `@snowball-tech/design-tokens`.
+
+Public/open-source (`snowball-tech/fractal`). **Freezer** is the primary
+consumer, pinning both packages to one exact version across every workspace.
+
+## Primitives-only, even here
+
+No composed/business components belong in this repo either — that's
+Freezer's `packages/common/components/` job. Keep every component here a
+primitive.
+
+## Component-authoring pattern
+
+Before adding a new component, search `packages/fractal/src/components/` for
+one that already covers the need (including a variant of an existing
+primitive) — don't create a near-duplicate.
+
+There is no scaffold script (no `plop`/`hygen`/generator in this repo). A
+component is `packages/fractal/src/components/<Component>/` with a fixed file
+quintet:
+
+- `<Component>.tsx`
+- `<Component>.types.ts`
+- `<Component>.constants.ts`
+- `<Component>.stories.tsx`
+- `<Component>.mdx`
+- `index.ts`
+
+Copy an existing folder (e.g. `Button/`) as the template. Don't invent a
+different shape or skip a file.
+
+## Design tokens govern visuals
+
+Colors, typography, spacing and shadows live in `packages/design-tokens` —
+see its [`DESIGN.md`](./packages/design-tokens/DESIGN.md). Read it before
+proposing new component visuals rather than inventing off-brand values.
+
+## Testing
+
+Mandatory for merge — see [`CONTRIBUTING.md`](./CONTRIBUTING.md).
+
+## Commits drive releases automatically
+
+Conventional Commits with Fractal's own extended type list (see
+[`CONTRIBUTING.md`](./CONTRIBUTING.md)) feed `multi-semantic-release` on
+merge to `main` — there is no manual version bump, ever. Get the commit type
+right or the release is wrong.
+
+## Storybook + its MCP endpoint
+
+`yarn dev` (or `yarn dev-storybook`) from `packages/fractal` starts Storybook
+on `:6006`. It exposes a live MCP endpoint at `http://localhost:6006/mcp`
+(see [`packages/fractal/README.md`](./packages/fractal/README.md) for the
+one-liner to register it: `npx mcp-add --type http --url
+"http://localhost:6006/mcp" --scope project`, run once at repo root).
+
+## Cross-repo coupling
+
+This is Freezer's pinned dependency (`@snowball-tech/fractal`, locked at one
+version across every Freezer workspace). A breaking change or a Tailwind
+version bump here can't ship solo — it has to be coordinated with Freezer
+(see Freezer's `docs/TOOLING.md`, which already documents "never bump
+tailwindcss" from the consumer side for exactly this reason).

--- a/yarn.lock
+++ b/yarn.lock
@@ -5383,12 +5383,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@snowball-tech/design-tokens@npm:17.1.5":
-  version: 17.1.5
-  resolution: "@snowball-tech/design-tokens@npm:17.1.5"
+"@snowball-tech/design-tokens@npm:17.2.0":
+  version: 17.2.0
+  resolution: "@snowball-tech/design-tokens@npm:17.2.0"
   dependencies:
     eslint: "npm:9.39.4"
-  checksum: 10/a48c65c03fb82482bb591a8414f4384f2f350cae72cc55c4e8ad8bb9ec7381baf600c5fb06e5562b631cdbb4e50894a828526ceb5a2d6b91aae3657bb4de25a4
+  checksum: 10/0ccde784620d6798289fccee108aa4377b9165722a64a792413740672e7dead394ad106fba30e9165333b8499595a8fcbcfa7d8995487ce25420da67d7f78481
   languageName: node
   linkType: hard
 
@@ -5480,7 +5480,7 @@ __metadata:
     "@radix-ui/react-toggle-group": "npm:1.1.11"
     "@radix-ui/react-toolbar": "npm:1.1.11"
     "@react-hookz/web": "npm:25.2.0"
-    "@snowball-tech/design-tokens": "npm:17.1.5"
+    "@snowball-tech/design-tokens": "npm:17.2.0"
     "@snowball-tech/eslint-snowball-config": "npm:2.1.0"
     "@snowball-tech/prettier-config": "npm:2.2.0"
     "@storybook/addon-a11y": "npm:10.4.1"


### PR DESCRIPTION
## What & why
Fractal had zero AI-agent-facing docs, no AGENTS.md, no CLAUDE.md, nothing telling an agent to read the existing human docs. Anyone working in this repo with an AI coding agent (fixing a bug, adding a primitive, touching design tokens) had no starting point, and there was no documented pattern for adding a new component at all.

## What changed
- New `AGENTS.md`: a pure index pointing to README, CONTRIBUTING, docs/CONVENTIONS, docs/TOOLING, docs/TROUBLESHOOTING, the design-tokens DESIGN.md brief, and the fractal package README.
- New `CLAUDE.md`: covers what wasn't documented anywhere else — the component file quintet (.tsx/.types.ts/.constants.ts/.stories.tsx/.mdx/index.ts, copy an existing folder like Button/), a search-before-adding-a-new-component rule, that commits drive releases automatically via multi-semantic-release, the Storybook MCP endpoint, and the cross-repo coupling with Freezer (which pins this package at an exact version).
- No existing docs were touched or restated — both files only point to what's already there.

## How to verify
- [ ] Every link in AGENTS.md and CLAUDE.md resolves to a real file in the repo.
- [ ] Open a fresh AI coding session rooted at this repo and ask "how do I add a new primitive component here?" — the answer should describe the file quintet and copying the Button/ folder, not invent a generator command.

## Notes
None.