### PR TITLE
feat: add figma-map & validation script

### DIFF
--- a/.claude/skills/fractal-create-pr/SKILL.md
+++ b/.claude/skills/fractal-create-pr/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: fractal-create-pr
+description: >-
+  Create a GitHub pull request for the Fractal repo with Snowball's
+  Conventional Commit title format. Use when the user asks to open, create,
+  or draft a PR, or otherwise signals the change is ready to ship.
+---
+
+# Create PR
+
+Create a pull request that follows this repo's conventions. See
+[`CONTRIBUTING.md`](../../../CONTRIBUTING.md) for the full commit rules.
+
+## Title
+
+PRs are squash-merged, so the title becomes the commit — it must match
+Conventional Commits:
+
+```text
+<type>[(scope)]: <subject in lowercase, no final period>
+```
+
+- `type`: one of the types in `CONTRIBUTING.md` (`feat`, `fix`, `breaking`,
+  `security`, `style`/`ui`/`ux`, `perf`, `docs`, `refactor`, `tests`,
+  `format`/`lint`, `build`, `ci`, `deps`, `chore`, ...) — get it right, it
+  drives the automatic release.
+- `scope`: the package (`fractal`, `design-tokens`) or a precise area.
+
+Examples:
+- `feat(fractal): add Combobox component`
+- `fix(design-tokens): correct shadow token value`
+
+## Body template
+
+```markdown
+## What
+
+<one or two sentences on what this PR does>
+
+## Why
+
+<the motivation / context>
+
+## How
+
+- <key change 1>
+- <key change 2>
+
+## Testing
+
+- [ ] <how you validated it — tests, Storybook, manual>
+
+## Notes
+
+<breaking changes, screenshots, follow-ups — or "N/A">
+```
+
+## Steps
+
+1. Check the current branch and its diff vs. `main`.
+2. Confirm tests exist for the change — required for merge per
+   `CONTRIBUTING.md`. Don't run the full `yarn quality` suite yourself (CI's
+   `quality.yml` already gates the PR); just sanity-check nothing obviously
+   broken.
+3. Scan the diff for anything that looks like a committed secret, key,
+   token, or `.env` value. If you find one, flag it and stop.
+4. Draft the title + body from the actual commits/diff — don't invent scope.
+5. Push the branch if needed, then create the PR with `gh`:
+
+```bash
+gh pr create --title "<title>" --body "$(cat <<'EOF'
+<body from template above>
+EOF
+)"
+```
+
+6. Return the PR URL.
+
+## Reminders
+
+- Squash-merge is the merge method — the title matters most; get the
+  Conventional Commit type right or the automatic release is wrong.

--- a/figma-map.json
+++ b/figma-map.json
@@ -1,0 +1,917 @@
+{
+  "meta": {
+    "description": "Figma <-> code mapping for the Fractal design system. Replaces Figma Code Connect (unavailable on our Figma plan). Consumed by AI agents (e.g. the design-contributor skill) to resolve a Figma selection to the exact Fractal component and props.",
+    "generated": "2026-07-23",
+    "fractalVersion": "27.1.1",
+    "figmaLibrary": "❄️ Fractal Design System",
+    "figmaFileKey": "kDNzWqTThmFHwYyHe9Cedk",
+    "importPattern": "import { <Component> } from '@snowball-tech/fractal/dist/src/components/<Component>'",
+    "conventions": [
+      "Figma variant properties reuse the exact code prop names and values; the default Figma variant is the code default.",
+      "Figma 'state' variants mix real code props (disabled, error, success) and pure interaction pseudo-states (hover, focus, pressed, open) that have NO code prop - they map to CSS states.",
+      "Figma TEXT properties map to the component's text content props (label, placeholder, title, children...).",
+      "Swappable icon slots default to uil/snowflake (placeholder). Swap targets are the uil/* components (see iconography).",
+      "Enforced (non-toggleable) state icons in Figma may be ahead of code - flagged with designAheadOfCode.",
+      "Every Figma component description also contains its source path and divergence flags."
+    ]
+  },
+  "iconography": {
+    "figmaPattern": "uil/<kebab-name> components on the '🧊 Icons' page (24x24, fill bound to color/icon/default)",
+    "reactImport": "import { Uil<PascalName> } from '@tooni/iconscout-unicons-react'",
+    "cssClass": "uil-<kebab-name>",
+    "example": {
+      "figma": "uil/angle-down",
+      "react": "UilAngleDown",
+      "css": "uil-angle-down"
+    }
+  },
+  "components": [
+    {
+      "figmaName": "Autocomplete",
+      "figmaNodeId": "185:73",
+      "codeComponent": "Autocomplete",
+      "source": "packages/fractal/src/components/Autocomplete",
+      "propMap": {
+        "open": {
+          "mapsTo": "open",
+          "note": "Figma variant showing the dropdown; code also supports uncontrolled behavior"
+        }
+      },
+      "notes": [
+        "Field texts (label, placeholder, description) live on nested exposed instances and map to label / placeholder / description / error / success."
+      ]
+    },
+    {
+      "figmaName": "Avatar",
+      "figmaNodeId": "84:34",
+      "codeComponent": "Avatar",
+      "source": "packages/fractal/src/components/Avatar",
+      "propMap": {
+        "size": {
+          "mapsTo": "size",
+          "note": "code also has 'fluid' (w-full) - not modeled"
+        },
+        "content": {
+          "mapsTo": "name | imageUrl | children",
+          "values": {
+            "initials": "name (initials derived)",
+            "image": "imageUrl",
+            "icon": "children (icon element)"
+          }
+        },
+        "initials": {
+          "mapsTo": "name"
+        }
+      },
+      "notes": [
+        "code prop 'disabled' not modeled.",
+        "In code, Avatar renders its children inside a Dropdown (avatar menu) - not modeled."
+      ]
+    },
+    {
+      "figmaName": "Badge",
+      "figmaNodeId": "77:8",
+      "codeComponent": "Badge",
+      "source": "packages/fractal/src/components/Badge",
+      "propMap": {
+        "type": {
+          "mapsTo": "count | label | children",
+          "values": {
+            "dot": "no content",
+            "count": "count (with 'limit' capping, code-only)",
+            "label": "label"
+          }
+        },
+        "label": {
+          "mapsTo": "count | label"
+        }
+      }
+    },
+    {
+      "figmaName": "Button",
+      "figmaNodeId": "49:14",
+      "codeComponent": "Button",
+      "source": "packages/fractal/src/components/Button",
+      "propMap": {
+        "variant": {
+          "mapsTo": "variant"
+        },
+        "state": {
+          "mapsTo": "disabled (state=disabled)",
+          "note": "hover/pressed are interaction pseudo-states, no code prop"
+        },
+        "iconLeft": {
+          "mapsTo": "icon + iconPosition='left'"
+        },
+        "iconRight": {
+          "mapsTo": "icon + iconPosition='right'"
+        },
+        "iconLeftSwap": {
+          "mapsTo": "icon (element)"
+        },
+        "iconRightSwap": {
+          "mapsTo": "icon (element)"
+        }
+      },
+      "notes": [
+        "Label text node maps to 'label'.",
+        "code props fullWidth and iconOnly not modeled."
+      ]
+    },
+    {
+      "figmaName": "Card",
+      "figmaNodeId": "76:20",
+      "codeComponent": "Card",
+      "source": "packages/fractal/src/components/Card",
+      "propMap": {
+        "color": {
+          "mapsTo": "color"
+        },
+        "fontSize": {
+          "mapsTo": "fontSize"
+        },
+        "dismissable": {
+          "mapsTo": "dismissable"
+        },
+        "title": {
+          "mapsTo": "title (presence)"
+        },
+        "titleText": {
+          "mapsTo": "title"
+        },
+        "icon": {
+          "mapsTo": "icon (presence)"
+        },
+        "iconSwap": {
+          "mapsTo": "icon"
+        },
+        "content": {
+          "mapsTo": "children"
+        }
+      },
+      "designAheadOfCode": "Feedback variants (success/warning/error) enforce state icons (uil/check-circle, uil/exclamation-triangle, uil/exclamation-circle) for color-blind accessibility. In code the consumer must pass them (candidate PR: auto-inject).",
+      "notes": [
+        "A toast IS a Card with dismissable=true - see freezer packages/common/components/layout/Toaster.tsx (no dedicated Figma component)."
+      ]
+    },
+    {
+      "figmaName": "Confirm",
+      "figmaNodeId": "216:45",
+      "codeComponent": "Confirm",
+      "source": "packages/fractal/src/components/Confirm",
+      "propMap": {
+        "condensed": {
+          "mapsTo": "condensed (inherited from Dialog)"
+        }
+      },
+      "notes": [
+        "Exposed Button instances map to 'cancel' (secondary) and 'confirm' (primary) props.",
+        "fixedActions=true (default) modeled; mobile stacked actions (to-md) not modeled."
+      ]
+    },
+    {
+      "figmaName": "CuteIcon",
+      "figmaNodeId": "201:36",
+      "codeComponent": "CuteIcon",
+      "source": "packages/fractal/src/components/CuteIcon",
+      "propMap": {
+        "color": {
+          "mapsTo": "color"
+        },
+        "icon": {
+          "mapsTo": "icon"
+        }
+      }
+    },
+    {
+      "figmaName": "DateTimePicker",
+      "figmaNodeId": "194:169",
+      "codeComponent": "DateTimePicker",
+      "source": "packages/fractal/src/components/DateTimePicker",
+      "propMap": {
+        "picker": {
+          "mapsTo": "withDatePicker / withTimePicker",
+          "values": {
+            "date": "withDatePicker",
+            "time": "withTimePicker"
+          }
+        }
+      },
+      "notes": [
+        "Figma models the open picker (code: staticPicker story). Field props follow the InputText mapping."
+      ]
+    },
+    {
+      "figmaName": "Dialog",
+      "figmaNodeId": "167:15",
+      "codeComponent": "Dialog",
+      "source": "packages/fractal/src/components/Dialog",
+      "propMap": {
+        "condensed": {
+          "mapsTo": "condensed"
+        },
+        "title": {
+          "mapsTo": "title"
+        },
+        "content": {
+          "mapsTo": "children"
+        },
+        "showClose": {
+          "mapsTo": "dismissable"
+        }
+      }
+    },
+    {
+      "figmaName": "Dropdown",
+      "figmaNodeId": "165:42",
+      "codeComponent": "Dropdown",
+      "source": "packages/fractal/src/components/Dropdown",
+      "propMap": {
+        "elevation": {
+          "mapsTo": "elevation"
+        }
+      },
+      "notes": ["Compose with exposed DropdownItem instances (children)."]
+    },
+    {
+      "figmaName": "DropdownItem",
+      "figmaNodeId": "165:15",
+      "codeComponent": "DropdownItem",
+      "source": "packages/fractal/src/components/Dropdown",
+      "propMap": {
+        "label": {
+          "mapsTo": "label"
+        },
+        "icon": {
+          "mapsTo": "icon (presence)"
+        },
+        "iconSwap": {
+          "mapsTo": "icon"
+        },
+        "state": {
+          "mapsTo": "disabled (state=disabled)",
+          "note": "hover is an interaction pseudo-state"
+        }
+      }
+    },
+    {
+      "figmaName": "InputCheckbox",
+      "figmaNodeId": "92:32",
+      "codeComponent": "InputCheckbox",
+      "source": "packages/fractal/src/components/InputCheckbox",
+      "propMap": {
+        "label": {
+          "mapsTo": "label / children"
+        },
+        "variant": {
+          "mapsTo": "variant"
+        },
+        "color": {
+          "mapsTo": "color"
+        },
+        "checked": {
+          "mapsTo": "checked / defaultChecked"
+        },
+        "disabled": {
+          "mapsTo": "disabled"
+        }
+      }
+    },
+    {
+      "figmaName": "InputDate",
+      "figmaNodeId": "178:37",
+      "codeComponent": "InputDate",
+      "source": "packages/fractal/src/components/InputDate",
+      "propMap": {
+        "showLabel": {
+          "mapsTo": "label (presence)"
+        },
+        "label": {
+          "mapsTo": "label"
+        },
+        "required": {
+          "mapsTo": "required"
+        },
+        "message": {
+          "mapsTo": "descriptions | error | success (per state)"
+        },
+        "state": {
+          "mapsTo": "error / success / disabled",
+          "note": "default = none of them"
+        }
+      }
+    },
+    {
+      "figmaName": "InputFile",
+      "figmaNodeId": "180:35",
+      "codeComponent": "InputFile",
+      "source": "packages/fractal/src/components/InputFile",
+      "propMap": {
+        "label": {
+          "mapsTo": "label"
+        },
+        "variant": {
+          "mapsTo": "variant (Button pass-through)"
+        },
+        "showIcon": {
+          "mapsTo": "icon (presence)"
+        },
+        "iconSwap": {
+          "mapsTo": "icon"
+        },
+        "disabled": {
+          "mapsTo": "disabled"
+        }
+      }
+    },
+    {
+      "figmaName": "InputPhone",
+      "figmaNodeId": "179:49",
+      "codeComponent": "InputPhone",
+      "source": "packages/fractal/src/components/InputPhone",
+      "propMap": {
+        "countryCode": {
+          "mapsTo": "countryCode",
+          "note": "display = emoji flag + ISO code (libphonenumber-js + country-flag-icons)"
+        },
+        "value": {
+          "mapsTo": "placeholder / defaultValue"
+        },
+        "showLabel": {
+          "mapsTo": "label (presence)"
+        },
+        "label": {
+          "mapsTo": "label"
+        },
+        "required": {
+          "mapsTo": "required"
+        },
+        "message": {
+          "mapsTo": "description | error | success (per state)"
+        },
+        "state": {
+          "mapsTo": "error / success / disabled"
+        }
+      }
+    },
+    {
+      "figmaName": "InputPinCode",
+      "figmaNodeId": "177:41",
+      "codeComponent": "InputPinCode",
+      "source": "packages/fractal/src/components/InputPinCode",
+      "propMap": {
+        "showLabel": {
+          "mapsTo": "label (presence)"
+        },
+        "label": {
+          "mapsTo": "label"
+        },
+        "required": {
+          "mapsTo": "required"
+        },
+        "message": {
+          "mapsTo": "description | error | success (per state)"
+        },
+        "state": {
+          "mapsTo": "error / success / disabled"
+        }
+      },
+      "notes": ["Number of digit cells is structural (code prop 'length')."]
+    },
+    {
+      "figmaName": "InputRadio",
+      "figmaNodeId": "93:45",
+      "codeComponent": "InputRadio",
+      "source": "packages/fractal/src/components/InputRadio",
+      "propMap": {
+        "label": {
+          "mapsTo": "label / children"
+        },
+        "variant": {
+          "mapsTo": "variant"
+        },
+        "checked": {
+          "mapsTo": "value / defaultValue",
+          "note": "radios come from InputRadioGroup: a radio is checked when the group value equals its value"
+        },
+        "disabled": {
+          "mapsTo": "disabled"
+        }
+      }
+    },
+    {
+      "figmaName": "InputText",
+      "figmaNodeId": "57:7",
+      "codeComponent": "InputText",
+      "source": "packages/fractal/src/components/InputText",
+      "propMap": {
+        "showLabel": {
+          "mapsTo": "label (presence)"
+        },
+        "label": {
+          "mapsTo": "label"
+        },
+        "required": {
+          "mapsTo": "required"
+        },
+        "prefixIcon": {
+          "mapsTo": "prefix (presence)"
+        },
+        "prefixIconSwap": {
+          "mapsTo": "prefix"
+        },
+        "suffixIcon": {
+          "mapsTo": "suffix (presence)"
+        },
+        "suffixIconSwap": {
+          "mapsTo": "suffix"
+        },
+        "value": {
+          "mapsTo": "placeholder (filled=false) / defaultValue (filled=true)"
+        },
+        "filled": {
+          "mapsTo": "value presence"
+        },
+        "showDescription": {
+          "mapsTo": "description (presence)"
+        },
+        "description": {
+          "mapsTo": "description"
+        },
+        "message": {
+          "mapsTo": "description | error | success (per state)"
+        },
+        "state": {
+          "mapsTo": "error / success / disabled",
+          "note": "hover/focus are interaction pseudo-states"
+        }
+      },
+      "designAheadOfCode": "error/success state icons (uil/exclamation-circle red, uil/check green) are enforced in Figma; in code the consumer provides the suffix (candidate PR: auto-inject)."
+    },
+    {
+      "figmaName": "Loader",
+      "figmaNodeId": "78:33",
+      "codeComponent": "Loader",
+      "source": "packages/fractal/src/components/Loader",
+      "propMap": {
+        "size": {
+          "mapsTo": "size"
+        }
+      }
+    },
+    {
+      "figmaName": "Logo",
+      "figmaNodeId": "203:955",
+      "codeComponent": "Logo",
+      "source": "packages/fractal/src/components/Logo",
+      "propMap": {
+        "size": {
+          "mapsTo": "size",
+          "note": "code default is 'fluid' (w-full) - not modeled"
+        },
+        "brandVariant": {
+          "mapsTo": "brandVariant"
+        }
+      },
+      "designAheadOfCode": "Only the text-only logo is modeled (pictoVariant='none' baked). Frames are tightened to the glyph; the code CSS box (75/150/225/300 wide) letterboxes it."
+    },
+    {
+      "figmaName": "Menu",
+      "figmaNodeId": "163:133",
+      "codeComponent": "Menu",
+      "source": "packages/fractal/src/components/Menu",
+      "propMap": {
+        "orientation": {
+          "mapsTo": "orientation"
+        },
+        "elevation": {
+          "mapsTo": "elevation"
+        }
+      },
+      "notes": ["Compose with exposed MenuItem instances (children)."]
+    },
+    {
+      "figmaName": "MenuItem",
+      "figmaNodeId": "158:15",
+      "codeComponent": "MenuItem",
+      "source": "packages/fractal/src/components/Menu",
+      "propMap": {
+        "label": {
+          "mapsTo": "label"
+        },
+        "icon": {
+          "mapsTo": "icon (presence)"
+        },
+        "iconSwap": {
+          "mapsTo": "icon"
+        },
+        "state": {
+          "mapsTo": "disabled (state=disabled)",
+          "note": "hover is an interaction pseudo-state"
+        }
+      }
+    },
+    {
+      "figmaName": "Paper",
+      "figmaNodeId": "74:18",
+      "codeComponent": "Paper",
+      "source": "packages/fractal/src/components/Paper",
+      "propMap": {
+        "elevation": {
+          "mapsTo": "elevation",
+          "note": "values are the code aliases: flat=0, light, bordered=1, elevated=2, higher=3"
+        },
+        "showTitle": {
+          "mapsTo": "title (presence)"
+        },
+        "title": {
+          "mapsTo": "title"
+        },
+        "content": {
+          "mapsTo": "children"
+        }
+      },
+      "notes": ["code collapsible/collapsed props not modeled."]
+    },
+    {
+      "figmaName": "Popover",
+      "figmaNodeId": "166:11",
+      "codeComponent": "Popover",
+      "source": "packages/fractal/src/components/Popover",
+      "propMap": {
+        "withArrow": {
+          "mapsTo": "withArrow",
+          "note": "⚠ defaults differ on purpose: Figma false (design choice), code true"
+        },
+        "elevation": {
+          "mapsTo": "elevation"
+        },
+        "content": {
+          "mapsTo": "children"
+        }
+      }
+    },
+    {
+      "figmaName": "Progress",
+      "figmaNodeId": "201:292",
+      "codeComponent": "Progress",
+      "source": "packages/fractal/src/components/Progress",
+      "propMap": {
+        "value": {
+          "mapsTo": "value / max",
+          "note": "code takes free numbers (default value=0, max=100); Figma discretizes to 0/20/60/100 (20 = Stepper current step, value 1 / max 5)"
+        }
+      }
+    },
+    {
+      "figmaName": "Select",
+      "figmaNodeId": "69:16",
+      "codeComponent": "Select",
+      "source": "packages/fractal/src/components/Select",
+      "propMap": {
+        "showLabel": {
+          "mapsTo": "label (presence)"
+        },
+        "label": {
+          "mapsTo": "label"
+        },
+        "required": {
+          "mapsTo": "required"
+        },
+        "value": {
+          "mapsTo": "placeholder (filled=false) / value-displayedValue (filled=true)"
+        },
+        "filled": {
+          "mapsTo": "value presence"
+        },
+        "state": {
+          "mapsTo": "disabled (state=disabled), open (state=open)",
+          "note": "hover is an interaction pseudo-state"
+        }
+      },
+      "notes": [
+        "Compose the open dropdown with exposed SelectItem instances (children)."
+      ]
+    },
+    {
+      "figmaName": "SelectItem",
+      "figmaNodeId": "67:9",
+      "codeComponent": "SelectItem",
+      "source": "packages/fractal/src/components/Select",
+      "propMap": {
+        "label": {
+          "mapsTo": "label / children"
+        },
+        "state": {
+          "mapsTo": "disabled (state=disabled)",
+          "note": "hover is an interaction pseudo-state"
+        }
+      }
+    },
+    {
+      "figmaName": "Skeleton",
+      "figmaNodeId": "80:43",
+      "codeComponent": "Skeleton",
+      "source": "packages/fractal/src/components/Skeleton",
+      "propMap": {
+        "shape": {
+          "mapsTo": "shape"
+        },
+        "color": {
+          "mapsTo": "color",
+          "note": "Figma pruned to actual product usage (grey, light-grey); code enum still allows 10 values (candidate PR: prune)"
+        }
+      }
+    },
+    {
+      "figmaName": "Slider",
+      "figmaNodeId": "185:19",
+      "codeComponent": "Slider",
+      "source": "packages/fractal/src/components/Slider",
+      "propMap": {
+        "orientation": {
+          "mapsTo": "orientation"
+        },
+        "disabled": {
+          "mapsTo": "disabled"
+        }
+      },
+      "notes": ["min/max/step/value/defaultValue are code-only."]
+    },
+    {
+      "figmaName": "Stepper",
+      "figmaNodeId": "201:294",
+      "codeComponent": "Stepper",
+      "source": "packages/fractal/src/components/Stepper",
+      "propMap": {},
+      "notes": [
+        "Composed of exposed Progress instances: completed step = value 100, current = value 20 (currentAs='step', i.e. 1/5), upcoming = value 0.",
+        "Add/remove instances to change 'length'; index of the 20% instance = 'current'.",
+        "currentAs='progress' renders the current step as a free-width progress bar (not modeled)."
+      ]
+    },
+    {
+      "figmaName": "Switch",
+      "figmaNodeId": "95:35",
+      "codeComponent": "Switch",
+      "source": "packages/fractal/src/components/Switch",
+      "propMap": {
+        "checked": {
+          "mapsTo": "checked / defaultChecked"
+        },
+        "disabled": {
+          "mapsTo": "disabled"
+        },
+        "label": {
+          "mapsTo": "label / children"
+        },
+        "labelLeft": {
+          "mapsTo": "labels (left side)"
+        },
+        "labelPosition": {
+          "mapsTo": "switchPosition / labels",
+          "note": "right = default label placement, left/both use the 'labels' + 'switchPosition' code props"
+        },
+        "showLabel": {
+          "mapsTo": "label (presence)"
+        }
+      }
+    },
+    {
+      "figmaName": "Tab",
+      "figmaNodeId": "205:380",
+      "codeComponent": "Tab",
+      "source": "packages/fractal/src/components/Tabs",
+      "propMap": {
+        "orientation": {
+          "mapsTo": "orientation (inherited from Tabs)"
+        },
+        "size": {
+          "mapsTo": "size (or tabsSize on Tabs)",
+          "values": {
+            "small": "small (caption-median)",
+            "medium": "medium (body-2-median)",
+            "large": "large (body-1-median)"
+          }
+        },
+        "selected": {
+          "mapsTo": "aria-selected state",
+          "note": "driven by Tabs defaultTab/tab, not a Tab prop"
+        },
+        "disabled": {
+          "mapsTo": "disabled"
+        },
+        "icon": {
+          "mapsTo": "icon (presence)"
+        },
+        "iconSwap": {
+          "mapsTo": "icon"
+        }
+      },
+      "notes": [
+        "Label text node maps to 'label'.",
+        "code: icon+label together forces large (min-h-10 / 80px) - not automatic in Figma.",
+        "iconOnly code-only (hide the label)."
+      ]
+    },
+    {
+      "figmaName": "Tabs",
+      "figmaNodeId": "206:74",
+      "codeComponent": "Tabs",
+      "source": "packages/fractal/src/components/Tabs",
+      "propMap": {
+        "variant": {
+          "mapsTo": "variant"
+        },
+        "orientation": {
+          "mapsTo": "orientation"
+        },
+        "withSeparator": {
+          "mapsTo": "withSeparator"
+        }
+      },
+      "notes": [
+        "Compose with exposed Tab instances (tabs prop).",
+        "fullWidth=true (code default) modeled; tabsPosition='end' and large bars not modeled."
+      ]
+    },
+    {
+      "figmaName": "Tag",
+      "figmaNodeId": "29:2",
+      "codeComponent": "Tag",
+      "source": "packages/fractal/src/components/Tag",
+      "propMap": {
+        "size": {
+          "mapsTo": "size"
+        },
+        "color": {
+          "mapsTo": "color"
+        },
+        "disabled": {
+          "mapsTo": "disabled"
+        },
+        "iconLeft": {
+          "mapsTo": "(no code prop)",
+          "note": "⚠ DESIGN AHEAD OF CODE - candidate PR: add icon/iconPosition to Tag.tsx"
+        },
+        "iconRight": {
+          "mapsTo": "(no code prop)",
+          "note": "⚠ DESIGN AHEAD OF CODE"
+        }
+      },
+      "notes": ["Label text node maps to 'children'.", "fullWidth code-only."]
+    },
+    {
+      "figmaName": "Textarea",
+      "figmaNodeId": "99:87",
+      "codeComponent": "Textarea",
+      "source": "packages/fractal/src/components/Textarea",
+      "propMap": {
+        "showLabel": {
+          "mapsTo": "label (presence)"
+        },
+        "label": {
+          "mapsTo": "label"
+        },
+        "required": {
+          "mapsTo": "required"
+        },
+        "value": {
+          "mapsTo": "placeholder (filled=false) / defaultValue (filled=true)"
+        },
+        "filled": {
+          "mapsTo": "value presence"
+        },
+        "message": {
+          "mapsTo": "description | error | success (per state)"
+        },
+        "state": {
+          "mapsTo": "error / success / disabled",
+          "note": "hover/focus are interaction pseudo-states"
+        }
+      }
+    },
+    {
+      "figmaName": "Toggle",
+      "figmaNodeId": "97:51",
+      "codeComponent": "Toggle",
+      "source": "packages/fractal/src/components/Toggle",
+      "propMap": {
+        "variant": {
+          "mapsTo": "variant"
+        },
+        "disabled": {
+          "mapsTo": "disabled"
+        },
+        "label": {
+          "mapsTo": "label / children"
+        },
+        "iconLeft": {
+          "mapsTo": "icon (presence)"
+        },
+        "iconRight": {
+          "mapsTo": "(no code prop)",
+          "note": "⚠ DESIGN AHEAD OF CODE - Toggle.tsx renders its single icon slot on the left only"
+        },
+        "toggled": {
+          "mapsTo": "toggled / defaultToggled"
+        }
+      }
+    },
+    {
+      "figmaName": "ToggleGroup",
+      "figmaNodeId": "98:53",
+      "codeComponent": "ToggleGroup",
+      "source": "packages/fractal/src/components/ToggleGroup",
+      "propMap": {
+        "orientation": {
+          "mapsTo": "orientation"
+        }
+      },
+      "notes": [
+        "Compose with exposed Toggle instances (children); set pressed/disabled per instance."
+      ]
+    },
+    {
+      "figmaName": "Toolbar",
+      "figmaNodeId": "213:408",
+      "codeComponent": "Toolbar",
+      "source": "packages/fractal/src/components/Toolbar",
+      "propMap": {
+        "orientation": {
+          "mapsTo": "orientation"
+        },
+        "disabled": {
+          "mapsTo": "disabled"
+        }
+      },
+      "designAheadOfCode": "Vertical orientation renders broken in code (wrapper h-5 clamp, candidate PR); Figma models the intended layout.",
+      "notes": [
+        "elevation baked to 'elevated' (code default); fullWidth code-only.",
+        "Compose with exposed ToolbarButton / ToolbarSeparator instances.",
+        "ToolbarDropdown = Dropdown reused inside a toolbar."
+      ]
+    },
+    {
+      "figmaName": "ToolbarButton",
+      "figmaNodeId": "213:31",
+      "codeComponent": "ToolbarButton",
+      "source": "packages/fractal/src/components/Toolbar",
+      "propMap": {
+        "active": {
+          "mapsTo": "active"
+        },
+        "disabled": {
+          "mapsTo": "disabled"
+        },
+        "iconOnly": {
+          "mapsTo": "iconOnly"
+        },
+        "icon": {
+          "mapsTo": "icon (presence)"
+        },
+        "iconSwap": {
+          "mapsTo": "icon"
+        }
+      },
+      "notes": [
+        "Label text node maps to 'label'; iconPosition code-only (reorder manually in Figma)."
+      ]
+    },
+    {
+      "figmaName": "ToolbarSeparator",
+      "figmaNodeId": "213:331",
+      "codeComponent": "ToolbarSeparator",
+      "source": "packages/fractal/src/components/Toolbar",
+      "propMap": {
+        "orientation": {
+          "mapsTo": "(inherited from the parent Toolbar in code)"
+        }
+      }
+    },
+    {
+      "figmaName": "Tooltip",
+      "figmaNodeId": "162:18",
+      "codeComponent": "Tooltip",
+      "source": "packages/fractal/src/components/Tooltip",
+      "propMap": {
+        "content": {
+          "mapsTo": "content"
+        },
+        "withArrow": {
+          "mapsTo": "withArrow"
+        },
+        "side": {
+          "mapsTo": "side"
+        }
+      }
+    }
+  ],
+  "notModeled": {
+    "EmojiPicker": "wraps the third-party emoji-mart web component - code-only",
+    "Header": "deferred - to redesign before modeling",
+    "Typography": "covered by the 26 published text styles (typography/*)",
+    "ScrollArea": "purely behavioral, nothing visual to model",
+    "Toaster (freezer)": "a toast is a Card with dismissable=true - use Card"
+  }
+}

--- a/scripts/validate-figma-map.mjs
+++ b/scripts/validate-figma-map.mjs
@@ -1,0 +1,177 @@
+#!/usr/bin/env node
+// Validates figma-map.json against the Fractal source code.
+// Guards against drift: a PR that renames/removes a component or prop
+// without updating the mapping makes this check fail.
+//
+// Usage: node scripts/validate-figma-map.mjs [path/to/figma-map.json]
+// Exit code: 1 if any error, 0 otherwise (warnings do not fail the build).
+
+import { existsSync, readdirSync, readFileSync } from 'node:fs'
+import { join, resolve } from 'node:path'
+
+const ROOT = resolve(process.cwd())
+const MAP_PATH = resolve(process.argv[2] ?? join(ROOT, 'figma-map.json'))
+
+// Tokens that are valid mapping targets but not component props.
+const ALLOWED_NON_PROPS = new Set([
+  'aria',
+  'capping',
+  'children',
+  'code',
+  'derived',
+  'element',
+  'from',
+  'icon',
+  'in',
+  'inherited',
+  'initials',
+  'left',
+  'limit',
+  'no',
+  'only',
+  'parent',
+  'pass',
+  'presence',
+  'prop',
+  'right',
+  'selected',
+  'side',
+  'state',
+  'states',
+  'the',
+  'through',
+  'with',
+])
+
+const errors = []
+const warnings = []
+
+const map = JSON.parse(readFileSync(MAP_PATH, 'utf8'))
+
+/**
+ * @param {string} directory
+ * @param {string[]} suffixes
+ */
+const readDirectoryTexts = (directory, suffixes) => {
+  let out = ''
+  for (const f of readdirSync(directory)) {
+    if (suffixes.some((s) => f.endsWith(s))) {
+      out += `${readFileSync(join(directory, f), 'utf8')}\n`
+    }
+  }
+
+  return out
+}
+
+/** @param {string} directory */
+const collectProps = (directory) => {
+  const props = new Set(['children', 'className', 'style'])
+  const types = readDirectoryTexts(directory, ['.types.ts'])
+  for (const m of types.matchAll(/^\s{2,}([a-zA-Z][a-zA-Z0-9]*)\??:/gm)) {
+    props.add(m[1])
+  }
+  // Props referenced through type composition (Pick<'a' | 'b'>, keyof lists...).
+  for (const m of types.matchAll(/'([a-zA-Z][a-zA-Z0-9]*)'/g)) {
+    props.add(m[1])
+  }
+
+  return props
+}
+
+/** @param {string} directory */
+const collectEnumValues = (directory) => {
+  const values = new Set()
+  const constants = readDirectoryTexts(directory, ['.constants.ts'])
+  for (const m of constants.matchAll(/=\s*'([a-zA-Z0-9-]+)'/g)) {
+    values.add(m[1])
+  }
+
+  return values
+}
+
+/**
+ * @param {string} directory
+ * @param {string} name
+ */
+const hasExport = (directory, name) => {
+  const code = readDirectoryTexts(directory, ['.tsx', '.ts'])
+
+  return (
+    new RegExp(`export const ${name}\\b`).test(code) ||
+    new RegExp(`export function ${name}\\b`).test(code) ||
+    new RegExp(`export \\{[^}]*\\b${name}\\b`).test(code)
+  )
+}
+
+/** @param {string} mapsTo */
+const extractPropTokens = (mapsTo) => {
+  if (/no code prop|pseudo-state|inherited from/i.test(mapsTo)) {
+    return []
+  }
+  // Strip parenthesised commentary, then keep identifier-looking tokens.
+  const stripped = mapsTo.replace(/\([^)]*\)/g, ' ')
+  const tokens = stripped.split(/[^a-zA-Z0-9]+/).filter(Boolean)
+
+  return tokens.filter(
+    (t) => /^[a-z][a-zA-Z0-9]*$/.test(t) && !ALLOWED_NON_PROPS.has(t),
+  )
+}
+
+for (const entry of map.components) {
+  const directory = join(ROOT, entry.source)
+  const label = `${entry.figmaName} -> ${entry.source}`
+
+  if (!existsSync(directory)) {
+    errors.push(`${label}: source directory not found`)
+    continue
+  }
+
+  if (!hasExport(directory, entry.codeComponent)) {
+    errors.push(`${label}: no export named '${entry.codeComponent}' found`)
+  }
+
+  const props = collectProps(directory)
+  const enums = collectEnumValues(directory)
+
+  for (const [figmaProp, definition] of Object.entries(entry.propMap ?? {})) {
+    for (const token of extractPropTokens(definition.mapsTo ?? '')) {
+      if (!props.has(token)) {
+        errors.push(
+          `${label}: propMap '${figmaProp}' targets unknown code prop '${token}'`,
+        )
+      }
+    }
+    for (const value of Object.keys(definition.values ?? {})) {
+      if (!enums.has(value) && !/^(true|false|\d+)$/.test(value)) {
+        warnings.push(
+          `${label}: variant value '${value}' (prop '${figmaProp}') not found in *.constants.ts enums`,
+        )
+      }
+    }
+  }
+}
+
+if (map.meta?.fractalVersion) {
+  const fractalPackage = JSON.parse(
+    readFileSync(join(ROOT, 'packages/fractal/package.json'), 'utf8'),
+  )
+  if (fractalPackage.version !== map.meta.fractalVersion) {
+    warnings.push(
+      `map was generated for fractal@${map.meta.fractalVersion}, package is now ${fractalPackage.version} - regenerate the map`,
+    )
+  }
+}
+
+for (const warning of warnings) {
+  console.warn(`WARN  ${warning}`)
+}
+for (const error of errors) {
+  console.error(`ERROR ${error}`)
+}
+console.info(
+  `figma-map: ${map.components.length} entries checked - ${errors.length} error(s), ${warnings.length} warning(s)`,
+)
+
+if (errors.length > 0) {
+  process.exit(1)
+}


### PR DESCRIPTION
## What

Adds a script that validates `figma-map.json` (the Figma ↔ code mapping consumed by AI agents to resolve a Figma selection to the right Fractal component/props) against the actual Fractal source. Also adds a project-scoped Claude Code skill for opening PRs in this repo.

## Why

Guards against drift: a PR that renames or removes a mapped component, export, or prop without updating the mapping would otherwise go unnoticed until an agent (or a human) hit a stale mapping.

## How

- `scripts/validate-figma-map.mjs`: for each mapped component, checks the source directory exists, the named export exists, every `propMap` target is a real prop (error), and every variant value exists in `*.constants.ts` enums (warning only, since some enums are intentionally partial).
- `figma-map.json`: the mapping data itself.
- `.claude/skills/fractal-create-pr/SKILL.md`: a Fractal-specific PR-creation skill (title/body conventions from this repo's own `CONTRIBUTING.md`).

## Testing

- [x] `node --check` + manual run against the real `figma-map.json` (41 entries, 0 errors, 8 expected warnings)
- [x] `yarn eslint` and `prettier --check` clean, plus a standalone `tsc --checkJs` pass (JSDoc-annotated, 0 implicit-any)
- [ ] No automated test suite — this is a root-level script, same as the existing `scripts/*.sh`, outside `packages/*`'s test setup

## Notes

N/A