### PR TITLE
fix(pin-code): clean up pasting a full code

### DIFF
--- a/packages/fractal/src/components/InputPinCode/InputPinCode.stories.tsx
+++ b/packages/fractal/src/components/InputPinCode/InputPinCode.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
 
 import { useArgs } from 'storybook/preview-api'
-import { fn, userEvent, within } from 'storybook/test'
+import { expect, fn, userEvent, waitFor, within } from 'storybook/test'
 
 import type {
   ChangeEvent,
@@ -99,6 +99,32 @@ export const Interactive: Story = {
     await slowType('3', inputs.at(3)!)
 
     await userEvent.click(inputs.at(4)!)
+  },
+}
+
+export const PasteFullCode: Story = {
+  args: {
+    length: 6,
+    onChange: fn(),
+    onComplete: fn(),
+    value: '',
+  },
+  play: async ({ args, canvasElement }) => {
+    const canvas = within(canvasElement)
+    const inputs = canvas.getAllByRole('spinbutton')
+
+    await userEvent.click(inputs[0]!)
+    // A code copied with a separator or a trailing newline must still
+    // land cleanly across every field.
+    await userEvent.paste('856 989\n')
+
+    await waitFor(() => {
+      ;['8', '5', '6', '9', '8', '9'].forEach((digit, index) => {
+        expect(inputs[index]).toHaveValue(Number(digit))
+      })
+    })
+
+    expect(args.onComplete).toHaveBeenCalledWith('856989')
   },
 }
 

--- a/packages/fractal/src/components/InputPinCode/InputPinCode.tsx
+++ b/packages/fractal/src/components/InputPinCode/InputPinCode.tsx
@@ -215,11 +215,15 @@ export const InputPinCode = ({
     event: ClipboardEvent<HTMLInputElement>,
     index: number,
   ) => {
+    event.preventDefault()
+
     if (isFunction(props.onPaste)) {
       props.onPaste(event)
     }
 
-    const pastedValue = event.clipboardData.getData('text/plain')
+    const pastedValue = event.clipboardData
+      .getData('text/plain')
+      .replace(/\s+/g, '')
     if (isEmpty(pastedValue)) {
       return
     }
@@ -232,9 +236,7 @@ export const InputPinCode = ({
       return
     }
 
-    const newValue = pastedValue
-      .slice(0, Math.max(0, length - index))
-      .padEnd(length - index - 1, '0')
+    const newValue = pastedValue.slice(0, Math.max(0, length - index))
 
     const oldCode = value || defaultValue || ''
     const newCode = `${oldCode.slice(0, Math.max(0, index))}${newValue}`

--- a/yarn.lock
+++ b/yarn.lock
@@ -5383,12 +5383,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@snowball-tech/design-tokens@npm:17.2.0":
-  version: 17.2.0
-  resolution: "@snowball-tech/design-tokens@npm:17.2.0"
+"@snowball-tech/design-tokens@npm:17.3.0":
+  version: 17.3.0
+  resolution: "@snowball-tech/design-tokens@npm:17.3.0"
   dependencies:
     eslint: "npm:9.39.4"
-  checksum: 10/0ccde784620d6798289fccee108aa4377b9165722a64a792413740672e7dead394ad106fba30e9165333b8499595a8fcbcfa7d8995487ce25420da67d7f78481
+  checksum: 10/bd13dfbd868ee3e54ad2dc53c9e6007153b282f9b044885026ade1ffe26a690ce63bef30ca1e8d7651349a86146fd69eda1c9cd817f6eca77a34dae43f75a3bc
   languageName: node
   linkType: hard
 
@@ -5480,7 +5480,7 @@ __metadata:
     "@radix-ui/react-toggle-group": "npm:1.1.11"
     "@radix-ui/react-toolbar": "npm:1.1.11"
     "@react-hookz/web": "npm:25.2.0"
-    "@snowball-tech/design-tokens": "npm:17.2.0"
+    "@snowball-tech/design-tokens": "npm:17.3.0"
     "@snowball-tech/eslint-snowball-config": "npm:2.1.0"
     "@snowball-tech/prettier-config": "npm:2.2.0"
     "@storybook/addon-a11y": "npm:10.4.1"


### PR DESCRIPTION
## What

Fixes pasting a full code into `InputPinCode` so it lands cleanly across every field, and covers it with an interaction test.

## Why

Pasting silently did nothing whenever the clipboard held anything beyond the raw digits — e.g. a code copied as "856 989" or with a trailing newline — because the digits-only check compared the pasted text verbatim. Separately, the native browser paste could also drop the raw clipboard text into the single focused field, since `maxLength` is ignored on `type="number"` inputs.

## How

- Strip whitespace from the pasted text before validating it, so a separator or trailing newline no longer breaks the paste.
- Call `preventDefault()` in the paste handler so the browser doesn't also insert the raw clipboard text into the field our own logic is already distributing.
- Drop a leftover `padEnd` that fabricated zero digits never present in the clipboard on a partial paste (pasting fewer digits than remaining fields).

## Testing

- [x] Added a Storybook interaction test (`PasteFullCode`) pasting a code with a separator and a trailing newline, asserting every field gets the right digit and `onComplete` fires with the clean code.
- [x] `yarn types-check` passes.
- [x] Manually verified in Storybook (Playground story) that a copied code with a space now pastes correctly.

## Notes

N/A