### PR TITLE
docs: update the Figma project link

### DIFF
--- a/packages/design-tokens/README.md
+++ b/packages/design-tokens/README.md
@@ -24,7 +24,7 @@ developer experience.
 Fractal documentation is also based on these design tokens.
 
 The original source of truth for these tokens is the
-[Figma project](https://www.figma.com/community/file/1281271374017743876/%E2%9D%84%EF%B8%8F-Fractal-Design-System)
+[Figma project](https://www.figma.com/community/file/1662066624978000289/fractal-design-system-v2)
 and all design tokens are regularly manually updated to stay synchronized with
 it.
 

--- a/packages/fractal/README.md
+++ b/packages/fractal/README.md
@@ -7,7 +7,7 @@ build products, apps, marketing contents and documentations.
 
 This package hosts the web (React) implementation of the components.
 
-The [Figma project](https://www.figma.com/community/file/1281271374017743876/%E2%9D%84%EF%B8%8F-Fractal-Design-System)
+The [Figma project](https://www.figma.com/community/file/1662066624978000289/fractal-design-system-v2)
 is the base reference for this design system and is used through the
 [design tokens](../design-tokens) package.
 The [documentation website](https://fractal.snowball.xyz/) is the core reference


### PR DESCRIPTION
## What

Updates the Fractal Figma community file link referenced in both package READMEs.

## Why

The Figma project moved to a new v2 URL: https://www.figma.com/community/file/1662066624978000289/fractal-design-system-v2

## How

- Replaced the old Figma link in `packages/fractal/README.md` and `packages/design-tokens/README.md`.

## Testing

- [x] N/A — doc-only link change.

## Notes

N/A